### PR TITLE
Added build_options.dynamic_origin check in ssr

### DIFF
--- a/src/handler.js
+++ b/src/handler.js
@@ -95,10 +95,13 @@ function serve(path, client = false) {
 /**@param {Request} req */
 function ssr(req) {
   let request = req;
-  let url = req.url;
-  let path = url.slice(url.split("/", 3).join("/").length);
-  let base = origin || get_origin(req.headers);
-  request = new Request(base + path, req);
+  
+  if (build_options.dynamic_origin) {
+    let url = req.url;
+    let path = url.slice(url.split("/", 3).join("/").length);
+    let base = origin || get_origin(req.headers);
+    request = new Request(base + path, req);
+  }
 
   if (address_header && !request.headers.has(address_header)) {
     throw new Error(


### PR DESCRIPTION
This was removed in the original repository in commit [`4a6fc41`](https://github.com/gornostay25/svelte-adapter-bun/commit/4a6fc413ddeecbbba6e9924de0a4884560e2a88a#diff-bf0009f43068a9b1f0340c7ce358f2692e49467646fb794a217e17f0f9785955L98). However, the removal courses the following error (#17).

```ts
1 | const test = async ({ request }) => {
2 |   const formData = await request.formData();
                             ^
TypeError: FormData parse error missing final boundary
      at /home/paul/svelte-adapter-bun-formdata/build/server/entries/pages/_page.server.ts.js:2:25
      at test (/home/paul/svelte-adapter-bun-formdata/build/server/entries/pages/_page.server.ts.js:1:13)
      at call_action (/home/paul/svelte-adapter-bun-formdata/build/server/index.js:569:27)
      at /home/paul/svelte-adapter-bun-formdata/build/server/index.js:455:23
      at handle_action_json_request (/home/paul/svelte-adapter-bun-formdata/build/server/index.js:434:42)
```

> **Note:** I do not know why it was removed and I also do not know what other implication this might have. I just know that this resolves the FormData parse error.